### PR TITLE
certs: rename certificates -> certs

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,4 +1,4 @@
-package certificates
+package certs
 
 import "github.com/giantswarm/microerror"
 

--- a/searcher.go
+++ b/searcher.go
@@ -1,4 +1,4 @@
-package certificates
+package certs
 
 import (
 	"fmt"

--- a/searcher_test.go
+++ b/searcher_test.go
@@ -1,4 +1,4 @@
-package certificates
+package certs
 
 import (
 	"reflect"

--- a/spec.go
+++ b/spec.go
@@ -1,4 +1,4 @@
-package certificates
+package certs
 
 type Interface interface {
 	SearchCluster(clusterID string) (Cluster, error)

--- a/types.go
+++ b/types.go
@@ -1,4 +1,4 @@
-package certificates
+package certs
 
 // These constants are used when filtering the secrets, to only retrieve the
 // ones we are interested in.


### PR DESCRIPTION
Repo is renamed from `certificates` to `certs` as discussed in #1.