### PR TITLE
certs: allow generating K8s Secret names

### DIFF
--- a/k8s.go
+++ b/k8s.go
@@ -1,0 +1,54 @@
+package certs
+
+import "fmt"
+
+// These constants are used when filtering the secrets, to only retrieve the
+// ones we are interested in.
+const (
+	// componentLabel is the label used in the secret to identify a secret
+	// containing the certificate.
+	//
+	// TODO replace with "giantswarm.io/certificate" and add to
+	// https://github.com/giantswarm/fmt.
+	certficateLabel = "clusterComponent"
+	// clusterIDLabel is the label used in the secret to identify a secret
+	// containing the certificate.
+	//
+	// TODO replace with "giantswarm.io/cluster-id"
+	clusterIDLabel = "clusterID"
+
+	SecretNamespace = "default"
+)
+
+// Cert is a certificate name.
+type Cert string
+
+// These constants used as Cert parsing a secret received from the API.
+const (
+	APICert              Cert = "api"
+	CalicoCert           Cert = "calico"
+	EtcdCert             Cert = "etcd"
+	FlanneldCert         Cert = "flanneld"
+	KubeStateMetricsCert Cert = "kube-state-metrics"
+	PrometheusCert       Cert = "prometheus"
+	ServiceAccountCert   Cert = "service-account"
+	WorkerCert           Cert = "worker"
+)
+
+// AllCerts lists all certificates that can be created by cert-operator.
+var AllCerts = []Cert{
+	APICert,
+	CalicoCert,
+	EtcdCert,
+	FlanneldCert,
+	KubeStateMetricsCert,
+	PrometheusCert,
+	ServiceAccountCert,
+	WorkerCert,
+}
+
+// K8sSecretName returns Kubernetes Secret object name for the certificate name
+// and the guest cluster ID.
+func K8sSecretName(clusterID, certificate Cert) string {
+	return fmt.Sprintf("%s-%s", clusterID, certificate)
+}

--- a/searcher.go
+++ b/searcher.go
@@ -65,13 +65,13 @@ func (s *Searcher) SearchCluster(clusterID string) (Cluster, error) {
 
 	certificates := []struct {
 		TLS  *TLS
-		Cert cert
+		Cert Cert
 	}{
-		{TLS: &cluster.APIServer, Cert: apiCert},
-		{TLS: &cluster.CalicoClient, Cert: calicoCert},
-		{TLS: &cluster.EtcdServer, Cert: etcdCert},
-		{TLS: &cluster.ServiceAccount, Cert: serviceAccountCert},
-		{TLS: &cluster.Worker, Cert: workerCert},
+		{TLS: &cluster.APIServer, Cert: APICert},
+		{TLS: &cluster.CalicoClient, Cert: CalicoCert},
+		{TLS: &cluster.EtcdServer, Cert: EtcdCert},
+		{TLS: &cluster.ServiceAccount, Cert: ServiceAccountCert},
+		{TLS: &cluster.Worker, Cert: WorkerCert},
 	}
 
 	for _, c := range certificates {
@@ -89,10 +89,10 @@ func (s *Searcher) SearchMonitoring(clusterID string) (Monitoring, error) {
 
 	certificates := []struct {
 		TLS  *TLS
-		Cert cert
+		Cert Cert
 	}{
-		{TLS: &monitoring.KubeStateMetrics, Cert: kubeStateMetricsCert},
-		{TLS: &monitoring.Prometheus, Cert: prometheusCert},
+		{TLS: &monitoring.KubeStateMetrics, Cert: KubeStateMetricsCert},
+		{TLS: &monitoring.Prometheus, Cert: PrometheusCert},
 	}
 
 	for _, c := range certificates {
@@ -105,14 +105,14 @@ func (s *Searcher) SearchMonitoring(clusterID string) (Monitoring, error) {
 	return monitoring, nil
 }
 
-func (s *Searcher) searchError(tls *TLS, clusterID string, cert cert, err error) error {
+func (s *Searcher) searchError(tls *TLS, clusterID string, cert Cert, err error) error {
 	if err != nil {
 		return err
 	}
 	return s.search(tls, clusterID, cert)
 }
 
-func (s *Searcher) search(tls *TLS, clusterID string, cert cert) error {
+func (s *Searcher) search(tls *TLS, clusterID string, cert Cert) error {
 	// Select only secrets that match the given certificate and the given
 	// cluster clusterID.
 	selector := fmt.Sprintf("%s=%s, %s=%s", certficateLabel, cert, clusterIDLabel, clusterID)
@@ -153,7 +153,7 @@ func (s *Searcher) search(tls *TLS, clusterID string, cert cert) error {
 	}
 }
 
-func fillTLSFromSecret(tls *TLS, obj runtime.Object, clusterID string, cert cert) error {
+func fillTLSFromSecret(tls *TLS, obj runtime.Object, clusterID string, cert Cert) error {
 	secret, ok := obj.(*corev1.Secret)
 	if !ok || secret == nil {
 		return microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", secret, obj)

--- a/searcher_test.go
+++ b/searcher_test.go
@@ -13,7 +13,7 @@ func Test_fillTLSFromSecret(t *testing.T) {
 
 	testCases := []struct {
 		ClusterID        string
-		Cert             cert
+		Cert             Cert
 		Secret           *corev1.Secret
 		ExpectedTLS      TLS
 		ExpectedErrMatch func(error) bool
@@ -21,7 +21,7 @@ func Test_fillTLSFromSecret(t *testing.T) {
 		// 0: ok.
 		{
 			ClusterID: "eggs2",
-			Cert:      cert("etcd"),
+			Cert:      Cert("etcd"),
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -45,7 +45,7 @@ func Test_fillTLSFromSecret(t *testing.T) {
 		// 1: cluster ID doesn't match.
 		{
 			ClusterID: "eggs5",
-			Cert:      cert("etcd"),
+			Cert:      Cert("etcd"),
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -65,7 +65,7 @@ func Test_fillTLSFromSecret(t *testing.T) {
 		// 2: cert doesn't match.
 		{
 			ClusterID: "eggs2",
-			Cert:      cert("calico"),
+			Cert:      Cert("calico"),
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -85,7 +85,7 @@ func Test_fillTLSFromSecret(t *testing.T) {
 		// 3: ca field missing.
 		{
 			ClusterID: "eggs2",
-			Cert:      cert("etcd"),
+			Cert:      Cert("etcd"),
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -104,7 +104,7 @@ func Test_fillTLSFromSecret(t *testing.T) {
 		// 4: crt field missing.
 		{
 			ClusterID: "eggs2",
-			Cert:      cert("etcd"),
+			Cert:      Cert("etcd"),
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
@@ -123,7 +123,7 @@ func Test_fillTLSFromSecret(t *testing.T) {
 		// 5: key field missing.
 		{
 			ClusterID: "eggs2",
-			Cert:      cert("etcd"),
+			Cert:      Cert("etcd"),
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/types.go
+++ b/types.go
@@ -1,38 +1,5 @@
 package certs
 
-// These constants are used when filtering the secrets, to only retrieve the
-// ones we are interested in.
-const (
-	// componentLabel is the label used in the secret to identify a secret
-	// containing the certificate.
-	//
-	// TODO replace with "giantswarm.io/certificate" and add to
-	// https://github.com/giantswarm/fmt.
-	certficateLabel = "clusterComponent"
-	// clusterIDLabel is the label used in the secret to identify a secret
-	// containing the certificate.
-	//
-	// TODO replace with "giantswarm.io/cluster-id"
-	clusterIDLabel = "clusterID"
-
-	SecretNamespace = "default"
-)
-
-type cert string
-
-// These constants used as Cert
-// parsing a secret received from the API.
-const (
-	apiCert              cert = "api"
-	calicoCert           cert = "calico"
-	etcdCert             cert = "etcd"
-	flanneldCert         cert = "flanneld"
-	kubeStateMetricsCert cert = "kube-state-metrics"
-	prometheusCert       cert = "prometheus"
-	serviceAccountCert   cert = "service-account"
-	workerCert           cert = "worker"
-)
-
 type TLS struct {
 	CA, Crt, Key []byte
 }


### PR DESCRIPTION
This is necessary in kubernetesd for creating cert-operator custom
objects.