### PR TITLE
added node operator certs for draining in master

### DIFF
--- a/certstest/searcher.go
+++ b/certstest/searcher.go
@@ -15,6 +15,10 @@ func (s *Searcher) SearchCluster(clusterID string) (certs.Cluster, error) {
 	return certs.Cluster{}, nil
 }
 
+func (s *Searcher) SearchDraining(clusterID string) (certs.Draining, error) {
+	return certs.Draining{}, nil
+}
+
 func (s *Searcher) SearchMonitoring(clusterID string) (certs.Monitoring, error) {
 	return certs.Monitoring{}, nil
 }

--- a/k8s.go
+++ b/k8s.go
@@ -30,6 +30,7 @@ const (
 	EtcdCert             Cert = "etcd"
 	FlanneldCert         Cert = "flanneld"
 	KubeStateMetricsCert Cert = "kube-state-metrics"
+	NodeOperatorCert     Cert = "node-operator"
 	PrometheusCert       Cert = "prometheus"
 	ServiceAccountCert   Cert = "service-account"
 	WorkerCert           Cert = "worker"
@@ -42,6 +43,7 @@ var AllCerts = []Cert{
 	EtcdCert,
 	FlanneldCert,
 	KubeStateMetricsCert,
+	NodeOperatorCert,
 	PrometheusCert,
 	ServiceAccountCert,
 	WorkerCert,

--- a/searcher.go
+++ b/searcher.go
@@ -84,6 +84,26 @@ func (s *Searcher) SearchCluster(clusterID string) (Cluster, error) {
 	return cluster, nil
 }
 
+func (s *Searcher) SearchDraining(clusterID string) (Draining, error) {
+	var draining Draining
+
+	certificates := []struct {
+		TLS  *TLS
+		Cert Cert
+	}{
+		{TLS: &draining.NodeOperator, Cert: NodeOperatorCert},
+	}
+
+	for _, c := range certificates {
+		err := s.search(c.TLS, clusterID, c.Cert)
+		if err != nil {
+			return Draining{}, microerror.Mask(err)
+		}
+	}
+
+	return draining, nil
+}
+
 func (s *Searcher) SearchMonitoring(clusterID string) (Monitoring, error) {
 	var monitoring Monitoring
 

--- a/spec.go
+++ b/spec.go
@@ -2,5 +2,6 @@ package certs
 
 type Interface interface {
 	SearchCluster(clusterID string) (Cluster, error)
+	SearchDraining(clusterID string) (Draining, error)
 	SearchMonitoring(clusterID string) (Monitoring, error)
 }

--- a/types.go
+++ b/types.go
@@ -12,6 +12,10 @@ type Cluster struct {
 	EtcdServer     TLS
 }
 
+type Draining struct {
+	NodeOperator TLS
+}
+
 type Monitoring struct {
 	Prometheus       TLS
 	KubeStateMetrics TLS


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2334. This change here is in `master`. We use this in the operators to fetch secrets containing key pairs. 