### PR TITLE
Remove KubeStateMetrics entry

### DIFF
--- a/k8s.go
+++ b/k8s.go
@@ -25,15 +25,14 @@ type Cert string
 
 // These constants used as Cert parsing a secret received from the API.
 const (
-	APICert              Cert = "api"
-	CalicoCert           Cert = "calico"
-	EtcdCert             Cert = "etcd"
-	FlanneldCert         Cert = "flanneld"
-	KubeStateMetricsCert Cert = "kube-state-metrics"
-	NodeOperatorCert     Cert = "node-operator"
-	PrometheusCert       Cert = "prometheus"
-	ServiceAccountCert   Cert = "service-account"
-	WorkerCert           Cert = "worker"
+	APICert            Cert = "api"
+	CalicoCert         Cert = "calico"
+	EtcdCert           Cert = "etcd"
+	FlanneldCert       Cert = "flanneld"
+	NodeOperatorCert   Cert = "node-operator"
+	PrometheusCert     Cert = "prometheus"
+	ServiceAccountCert Cert = "service-account"
+	WorkerCert         Cert = "worker"
 )
 
 // AllCerts lists all certificates that can be created by cert-operator.
@@ -42,7 +41,6 @@ var AllCerts = []Cert{
 	CalicoCert,
 	EtcdCert,
 	FlanneldCert,
-	KubeStateMetricsCert,
 	NodeOperatorCert,
 	PrometheusCert,
 	ServiceAccountCert,

--- a/searcher.go
+++ b/searcher.go
@@ -111,7 +111,6 @@ func (s *Searcher) SearchMonitoring(clusterID string) (Monitoring, error) {
 		TLS  *TLS
 		Cert Cert
 	}{
-		{TLS: &monitoring.KubeStateMetrics, Cert: KubeStateMetricsCert},
 		{TLS: &monitoring.Prometheus, Cert: PrometheusCert},
 	}
 


### PR DESCRIPTION
Initial idea was to use HTTPS for kube-state-metrics but that was
dropped and currently only HTTP is used. Therefore there is no need for
KubeStateMetrics entry nor does anything use it currently (certconfig for
it doesn't exist in any current cluster).