### PR TITLE
configures watch timeout

### DIFF
--- a/error.go
+++ b/error.go
@@ -4,7 +4,7 @@ import "github.com/giantswarm/microerror"
 
 var executionError = microerror.New("execution error")
 
-func IsExecutionError(err error) bool {
+func IsExecution(err error) bool {
 	return microerror.Cause(err) == executionError
 }
 
@@ -22,12 +22,12 @@ func IsInvalidSecret(err error) bool {
 
 var timeoutError = microerror.New("timeout")
 
-func IsTimeoutError(err error) bool {
+func IsTimeout(err error) bool {
 	return microerror.Cause(err) == timeoutError
 }
 
 var wrongTypeError = microerror.New("wrong type")
 
-func IsWrongTypeError(err error) bool {
+func IsWrongType(err error) bool {
 	return microerror.Cause(err) == wrongTypeError
 }

--- a/searcher.go
+++ b/searcher.go
@@ -15,23 +15,23 @@ import (
 )
 
 const (
-	// DefaultWatchTimeOut is the time to wait on watches against the Kubernetes
+	// DefaultWatchTimeout is the time to wait on watches against the Kubernetes
 	// API before giving up and throwing an error.
-	DefaultWatchTimeOut = 90 * time.Second
+	DefaultWatchTimeout = 90 * time.Second
 )
 
 type Config struct {
 	K8sClient kubernetes.Interface
 	Logger    micrologger.Logger
 
-	WatchTimeOut time.Duration
+	WatchTimeout time.Duration
 }
 
 type Searcher struct {
 	k8sClient kubernetes.Interface
 	logger    micrologger.Logger
 
-	watchTimeOut time.Duration
+	watchTimeout time.Duration
 }
 
 func NewSearcher(config Config) (*Searcher, error) {
@@ -42,15 +42,15 @@ func NewSearcher(config Config) (*Searcher, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
-	if config.WatchTimeOut == 0 {
-		config.WatchTimeOut = DefaultWatchTimeOut
+	if config.WatchTimeout == 0 {
+		config.WatchTimeout = DefaultWatchTimeout
 	}
 
 	s := &Searcher{
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,
 
-		watchTimeOut: config.WatchTimeOut,
+		watchTimeout: config.WatchTimeout,
 	}
 
 	return s, nil
@@ -182,7 +182,7 @@ func (s *Searcher) search(tls *TLS, clusterID string, cert Cert) error {
 			case watch.Error:
 				return microerror.Maskf(executionError, "watching secrets, selector = %q: %v", selector, apierrors.FromObject(event.Object))
 			}
-		case <-time.After(s.watchTimeOut):
+		case <-time.After(s.watchTimeout):
 			return microerror.Maskf(timeoutError, "waiting secrets, selector = %q", selector)
 		}
 	}

--- a/searcher.go
+++ b/searcher.go
@@ -15,20 +15,26 @@ import (
 )
 
 const (
-	// watchTimeOut is the time to wait on watches against the Kubernetes API
-	// before giving up and throwing an error.
-	watchTimeOut = 90 * time.Second
+	// DefaultWatchTimeOut is the time to wait on watches against the Kubernetes
+	// API before giving up and throwing an error.
+	DefaultWatchTimeOut = 90 * time.Second
 )
 
 type Config struct {
-	// Dependencies.
-
 	K8sClient kubernetes.Interface
 	Logger    micrologger.Logger
+
+	WatchTimeOut time.Duration
+}
+
+type Searcher struct {
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+
+	watchTimeOut time.Duration
 }
 
 func NewSearcher(config Config) (*Searcher, error) {
-	// Dependencies.
 	if config.K8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
 	}
@@ -36,20 +42,18 @@ func NewSearcher(config Config) (*Searcher, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
+	if config.WatchTimeOut == 0 {
+		config.WatchTimeOut = DefaultWatchTimeOut
+	}
+
 	s := &Searcher{
-		// Dependencies.
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,
+
+		watchTimeOut: config.WatchTimeOut,
 	}
 
 	return s, nil
-}
-
-type Searcher struct {
-	// Dependencies.
-
-	k8sClient kubernetes.Interface
-	logger    micrologger.Logger
 }
 
 func (s *Searcher) SearchCluster(clusterID string) (Cluster, error) {
@@ -178,7 +182,7 @@ func (s *Searcher) search(tls *TLS, clusterID string, cert Cert) error {
 			case watch.Error:
 				return microerror.Maskf(executionError, "watching secrets, selector = %q: %v", selector, apierrors.FromObject(event.Object))
 			}
-		case <-time.After(watchTimeOut):
+		case <-time.After(s.watchTimeOut):
 			return microerror.Maskf(timeoutError, "waiting secrets, selector = %q", selector)
 		}
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2879. In the node-operator for instance we want to fail faster. We do not need to wait 90 seconds for certs to be there. The big watch time out is used for actions at the beginning of a guest cluster lifecycle. The node-operator operators on the other end. We can use a way smaller watch timeout then and fail fast. 