### PR TITLE
Add separate etcd client keys for calico and flanneld

### DIFF
--- a/files.go
+++ b/files.go
@@ -57,19 +57,31 @@ func newFilesClusterCommon(cluster Cluster) Files {
 			AbsolutePath: "/etc/kubernetes/ssl/calico/client-key.pem",
 			Data:         cluster.CalicoClient.Key,
 		},
-		// Etcd client.
-		// TODO create separate etcd client certificates.
+		// Calico Etcd client.
 		{
-			AbsolutePath: "/etc/kubernetes/ssl/etcd/client-ca.pem",
-			Data:         cluster.EtcdServer.CA,
+			AbsolutePath: "/etc/kubernetes/ssl/etcd/calico-client-ca.pem",
+			Data:         cluster.CalicoEtcdClient.CA,
 		},
 		{
-			AbsolutePath: "/etc/kubernetes/ssl/etcd/client-crt.pem",
-			Data:         cluster.EtcdServer.Crt,
+			AbsolutePath: "/etc/kubernetes/ssl/etcd/calico-client-crt.pem",
+			Data:         cluster.CalicoEtcdClient.Crt,
 		},
 		{
-			AbsolutePath: "/etc/kubernetes/ssl/etcd/client-key.pem",
-			Data:         cluster.EtcdServer.Key,
+			AbsolutePath: "/etc/kubernetes/ssl/etcd/calico-client-key.pem",
+			Data:         cluster.CalicoEtcdClient.Key,
+		},
+		// Flanneld Etcd client.
+		{
+			AbsolutePath: "/etc/kubernetes/ssl/etcd/flanneld-client-ca.pem",
+			Data:         cluster.FlanneldEtcdClient.CA,
+		},
+		{
+			AbsolutePath: "/etc/kubernetes/ssl/etcd/flanneld-client-crt.pem",
+			Data:         cluster.FlanneldEtcdClient.Crt,
+		},
+		{
+			AbsolutePath: "/etc/kubernetes/ssl/etcd/flanneld-client-key.pem",
+			Data:         cluster.FlanneldEtcdClient.Key,
 		},
 	}
 }

--- a/files.go
+++ b/files.go
@@ -85,19 +85,6 @@ func newFilesClusterCommon(cluster Cluster) Files {
 			AbsolutePath: "/etc/kubernetes/ssl/etcd/calico-client-key.pem",
 			Data:         cluster.CalicoEtcdClient.Key,
 		},
-		// Flanneld Etcd client.
-		{
-			AbsolutePath: "/etc/kubernetes/ssl/etcd/flanneld-client-ca.pem",
-			Data:         cluster.FlanneldEtcdClient.CA,
-		},
-		{
-			AbsolutePath: "/etc/kubernetes/ssl/etcd/flanneld-client-crt.pem",
-			Data:         cluster.FlanneldEtcdClient.Crt,
-		},
-		{
-			AbsolutePath: "/etc/kubernetes/ssl/etcd/flanneld-client-key.pem",
-			Data:         cluster.FlanneldEtcdClient.Key,
-		},
 	}
 }
 

--- a/files.go
+++ b/files.go
@@ -57,6 +57,21 @@ func newFilesClusterCommon(cluster Cluster) Files {
 			AbsolutePath: "/etc/kubernetes/ssl/calico/client-key.pem",
 			Data:         cluster.CalicoClient.Key,
 		},
+		// Temporary Etcd client keys reusing server keys.
+		// TODO Remove these when operator support for new flannel & calico
+		// specific etcd client keys has been rolled out.
+		{
+			AbsolutePath: "/etc/kubernetes/ssl/etcd/client-ca.pem",
+			Data:         cluster.EtcdServer.CA,
+		},
+		{
+			AbsolutePath: "/etc/kubernetes/ssl/etcd/client-crt.pem",
+			Data:         cluster.EtcdServer.Crt,
+		},
+		{
+			AbsolutePath: "/etc/kubernetes/ssl/etcd/client-key.pem",
+			Data:         cluster.EtcdServer.Key,
+		},
 		// Calico Etcd client.
 		{
 			AbsolutePath: "/etc/kubernetes/ssl/etcd/calico-client-ca.pem",

--- a/k8s.go
+++ b/k8s.go
@@ -31,7 +31,6 @@ const (
 	ClusterOperatorAPICert Cert = "cluster-operator-api"
 	EtcdCert               Cert = "etcd"
 	FlanneldCert           Cert = "flanneld"
-	FlanneldEtcdClientCert Cert = "flanneld-etcd-client"
 	NodeOperatorCert       Cert = "node-operator"
 	PrometheusCert         Cert = "prometheus"
 	ServiceAccountCert     Cert = "service-account"
@@ -46,7 +45,6 @@ var AllCerts = []Cert{
 	ClusterOperatorAPICert,
 	EtcdCert,
 	FlanneldCert,
-	FlanneldEtcdClientCert,
 	NodeOperatorCert,
 	PrometheusCert,
 	ServiceAccountCert,

--- a/k8s.go
+++ b/k8s.go
@@ -27,9 +27,11 @@ type Cert string
 const (
 	APICert                Cert = "api"
 	CalicoCert             Cert = "calico"
+	CalicoEtcdClientCert   Cert = "calico-etcd-client"
 	ClusterOperatorAPICert Cert = "cluster-operator-api"
 	EtcdCert               Cert = "etcd"
 	FlanneldCert           Cert = "flanneld"
+	FlanneldEtcdClientCert Cert = "flanneld-etcd-client"
 	NodeOperatorCert       Cert = "node-operator"
 	PrometheusCert         Cert = "prometheus"
 	ServiceAccountCert     Cert = "service-account"
@@ -40,9 +42,11 @@ const (
 var AllCerts = []Cert{
 	APICert,
 	CalicoCert,
+	CalicoEtcdClientCert,
 	ClusterOperatorAPICert,
 	EtcdCert,
 	FlanneldCert,
+	FlanneldEtcdClientCert,
 	NodeOperatorCert,
 	PrometheusCert,
 	ServiceAccountCert,

--- a/searcher.go
+++ b/searcher.go
@@ -65,7 +65,9 @@ func (s *Searcher) SearchCluster(clusterID string) (Cluster, error) {
 	}{
 		{TLS: &cluster.APIServer, Cert: APICert},
 		{TLS: &cluster.CalicoClient, Cert: CalicoCert},
+		{TLS: &cluster.CalicoEtcdClient, Cert: CalicoEtcdClientCert},
 		{TLS: &cluster.EtcdServer, Cert: EtcdCert},
+		{TLS: &cluster.FlanneldEtcdClient, Cert: FlanneldEtcdClientCert},
 		{TLS: &cluster.ServiceAccount, Cert: ServiceAccountCert},
 		{TLS: &cluster.Worker, Cert: WorkerCert},
 	}

--- a/searcher.go
+++ b/searcher.go
@@ -67,7 +67,6 @@ func (s *Searcher) SearchCluster(clusterID string) (Cluster, error) {
 		{TLS: &cluster.CalicoClient, Cert: CalicoCert},
 		{TLS: &cluster.CalicoEtcdClient, Cert: CalicoEtcdClientCert},
 		{TLS: &cluster.EtcdServer, Cert: EtcdCert},
-		{TLS: &cluster.FlanneldEtcdClient, Cert: FlanneldEtcdClientCert},
 		{TLS: &cluster.ServiceAccount, Cert: ServiceAccountCert},
 		{TLS: &cluster.Worker, Cert: WorkerCert},
 	}

--- a/types.go
+++ b/types.go
@@ -5,13 +5,12 @@ type TLS struct {
 }
 
 type Cluster struct {
-	APIServer          TLS
-	CalicoClient       TLS
-	CalicoEtcdClient   TLS
-	EtcdServer         TLS
-	FlanneldEtcdClient TLS
-	ServiceAccount     TLS
-	Worker             TLS
+	APIServer        TLS
+	CalicoClient     TLS
+	CalicoEtcdClient TLS
+	EtcdServer       TLS
+	ServiceAccount   TLS
+	Worker           TLS
 }
 
 type ClusterOperator struct {

--- a/types.go
+++ b/types.go
@@ -5,11 +5,13 @@ type TLS struct {
 }
 
 type Cluster struct {
-	APIServer      TLS
-	Worker         TLS
-	ServiceAccount TLS
-	CalicoClient   TLS
-	EtcdServer     TLS
+	APIServer          TLS
+	CalicoClient       TLS
+	CalicoEtcdClient   TLS
+	EtcdServer         TLS
+	FlanneldEtcdClient TLS
+	ServiceAccount     TLS
+	Worker             TLS
 }
 
 type ClusterOperator struct {
@@ -21,6 +23,6 @@ type Draining struct {
 }
 
 type Monitoring struct {
-	Prometheus       TLS
 	KubeStateMetrics TLS
+	Prometheus       TLS
 }


### PR DESCRIPTION
So far all etcd clients used server keys which is not secure
authentication wise. Add separate etcd client keys for flanneld and
calico.

Towards https://github.com/giantswarm/giantswarm/issues/1500 and https://github.com/giantswarm/giantswarm/issues/1559