### PR TITLE
Make CalicoEtcdClient cert optional for searcher

### DIFF
--- a/searcher.go
+++ b/searcher.go
@@ -60,12 +60,13 @@ func (s *Searcher) SearchCluster(clusterID string) (Cluster, error) {
 	var cluster Cluster
 
 	certificates := []struct {
-		TLS  *TLS
-		Cert Cert
+		TLS      *TLS
+		Cert     Cert
+		optional bool
 	}{
 		{TLS: &cluster.APIServer, Cert: APICert},
 		{TLS: &cluster.CalicoClient, Cert: CalicoCert},
-		{TLS: &cluster.CalicoEtcdClient, Cert: CalicoEtcdClientCert},
+		{TLS: &cluster.CalicoEtcdClient, Cert: CalicoEtcdClientCert, optional: true},
 		{TLS: &cluster.EtcdServer, Cert: EtcdCert},
 		{TLS: &cluster.ServiceAccount, Cert: ServiceAccountCert},
 		{TLS: &cluster.Worker, Cert: WorkerCert},
@@ -73,7 +74,7 @@ func (s *Searcher) SearchCluster(clusterID string) (Cluster, error) {
 
 	for _, c := range certificates {
 		err := s.search(c.TLS, clusterID, c.Cert)
-		if err != nil {
+		if !c.optional && err != nil {
 			return Cluster{}, microerror.Mask(err)
 		}
 	}

--- a/searcher.go
+++ b/searcher.go
@@ -74,8 +74,12 @@ func (s *Searcher) SearchCluster(clusterID string) (Cluster, error) {
 
 	for _, c := range certificates {
 		err := s.search(c.TLS, clusterID, c.Cert)
-		if !c.optional && err != nil {
-			return Cluster{}, microerror.Mask(err)
+		if err != nil {
+			if c.optional {
+				s.logger.Log("level", "warning", "message", err.Error())
+			} else {
+				return Cluster{}, microerror.Mask(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
When introducing cert for calico etcd client keys it was initially
thought that adding it here doesn't break anything as nothing uses it.
This was wrong thinking. Adding it to searcher actually takes it into
use everywhere and initially this was fixed by creating corresponding
certconfig in kubernetesd and cluster-operator. Now there's still
problem with old clusters that don't have this so therefore it should be
made optional for now.

As of now this is a pressing issue on old clusters which cannot change in any way due to this restriction.