### PR TITLE
Add cert name for flanneld etcd client cert

### DIFF
--- a/k8s.go
+++ b/k8s.go
@@ -31,6 +31,7 @@ const (
 	ClusterOperatorAPICert Cert = "cluster-operator-api"
 	EtcdCert               Cert = "etcd"
 	FlanneldCert           Cert = "flanneld"
+	FlanneldEtcdClientCert Cert = "flanneld-etcd-client"
 	NodeOperatorCert       Cert = "node-operator"
 	PrometheusCert         Cert = "prometheus"
 	ServiceAccountCert     Cert = "service-account"
@@ -45,6 +46,7 @@ var AllCerts = []Cert{
 	ClusterOperatorAPICert,
 	EtcdCert,
 	FlanneldCert,
+	FlanneldEtcdClientCert,
 	NodeOperatorCert,
 	PrometheusCert,
 	ServiceAccountCert,

--- a/k8s.go
+++ b/k8s.go
@@ -30,7 +30,6 @@ const (
 	CalicoEtcdClientCert   Cert = "calico-etcd-client"
 	ClusterOperatorAPICert Cert = "cluster-operator-api"
 	EtcdCert               Cert = "etcd"
-	FlanneldCert           Cert = "flanneld"
 	FlanneldEtcdClientCert Cert = "flanneld-etcd-client"
 	NodeOperatorCert       Cert = "node-operator"
 	PrometheusCert         Cert = "prometheus"
@@ -45,7 +44,6 @@ var AllCerts = []Cert{
 	CalicoEtcdClientCert,
 	ClusterOperatorAPICert,
 	EtcdCert,
-	FlanneldCert,
 	FlanneldEtcdClientCert,
 	NodeOperatorCert,
 	PrometheusCert,


### PR DESCRIPTION
Only commonly agreed cert name is needed here for flanneld etcd client
cert. Then cluster-operator can create certconfig for this and
flannel-operator can mount named secret to flanneld daemonset.

Towards https://github.com/giantswarm/giantswarm/issues/1559