### PR TITLE
adds support for general searching of TLS assets based on identifier

### DIFF
--- a/certstest/searcher.go
+++ b/certstest/searcher.go
@@ -26,3 +26,7 @@ func (s *Searcher) SearchClusterOperator(clusterID string) (certs.ClusterOperato
 func (s *Searcher) SearchMonitoring(clusterID string) (certs.Monitoring, error) {
 	return certs.Monitoring{}, nil
 }
+
+func (s *Searcher) SearchTLS(clusterID string, cert certs.Cert) (certs.TLS, error) {
+	return certs.TLS{}, nil
+}

--- a/searcher.go
+++ b/searcher.go
@@ -146,11 +146,15 @@ func (s *Searcher) SearchMonitoring(clusterID string) (Monitoring, error) {
 	return monitoring, nil
 }
 
-func (s *Searcher) searchError(tls *TLS, clusterID string, cert Cert, err error) error {
+func (s *Searcher) SearchTLS(clusterID string, cert Cert) (TLS, error) {
+	tls := &TLS{}
+
+	err := s.search(tls, clusterID, cert)
 	if err != nil {
-		return err
+		return TLS{}, microerror.Mask(err)
 	}
-	return s.search(tls, clusterID, cert)
+
+	return *tls, nil
 }
 
 func (s *Searcher) search(tls *TLS, clusterID string, cert Cert) error {

--- a/spec.go
+++ b/spec.go
@@ -13,8 +13,8 @@ type Interface interface {
 	// SearchMonitoring searches for secrets containing TLS certs for
 	// monitoring guest clusters.
 	SearchMonitoring(clusterID string) (Monitoring, error)
-}
-
-type TLSSearcher interface {
+	// SearchTLS provides a dedicated way to lookup a single TLS asset for one
+	// specific purpose. This might be used for e.g. granting guest cluster
+	// access within operators.
 	SearchTLS(clusterID string, cert Cert) (TLS, error)
 }

--- a/spec.go
+++ b/spec.go
@@ -14,3 +14,7 @@ type Interface interface {
 	// monitoring guest clusters.
 	SearchMonitoring(clusterID string) (Monitoring, error)
 }
+
+type TLSSearcher interface {
+	SearchTLS(clusterID string, cert Cert) (TLS, error)
+}


### PR DESCRIPTION
See https://github.com/giantswarm/guestcluster/pull/2 and https://github.com/giantswarm/node-operator/pull/47. 