### PR TITLE
Use proper names for Calico certificates and remove unnecessary ceritifcates

### DIFF
--- a/files.go
+++ b/files.go
@@ -44,22 +44,8 @@ func NewFilesClusterWorker(cluster Cluster) Files {
 
 func newFilesClusterCommon(cluster Cluster) Files {
 	return Files{
-		// Calico client.
-		{
-			AbsolutePath: "/etc/kubernetes/ssl/calico/client-ca.pem",
-			Data:         cluster.CalicoClient.CA,
-		},
-		{
-			AbsolutePath: "/etc/kubernetes/ssl/calico/client-crt.pem",
-			Data:         cluster.CalicoClient.Crt,
-		},
-		{
-			AbsolutePath: "/etc/kubernetes/ssl/calico/client-key.pem",
-			Data:         cluster.CalicoClient.Key,
-		},
-		// Temporary Etcd client keys reusing server keys.
-		// TODO Remove these when operator support for new flannel & calico
-		// specific etcd client keys has been rolled out.
+		// TODO(r7vme): Only used by Calico and should be removed
+		// when Calico will migrate to the ones below.
 		{
 			AbsolutePath: "/etc/kubernetes/ssl/etcd/client-ca.pem",
 			Data:         cluster.EtcdServer.CA,
@@ -74,15 +60,15 @@ func newFilesClusterCommon(cluster Cluster) Files {
 		},
 		// Calico Etcd client.
 		{
-			AbsolutePath: "/etc/kubernetes/ssl/etcd/calico-client-ca.pem",
+			AbsolutePath: "/etc/kubernetes/ssl/calico/etcd-ca",
 			Data:         cluster.CalicoEtcdClient.CA,
 		},
 		{
-			AbsolutePath: "/etc/kubernetes/ssl/etcd/calico-client-crt.pem",
+			AbsolutePath: "/etc/kubernetes/ssl/calico/etcd-cert",
 			Data:         cluster.CalicoEtcdClient.Crt,
 		},
 		{
-			AbsolutePath: "/etc/kubernetes/ssl/etcd/calico-client-key.pem",
+			AbsolutePath: "/etc/kubernetes/ssl/calico/etcd-key",
 			Data:         cluster.CalicoEtcdClient.Key,
 		},
 	}

--- a/k8s.go
+++ b/k8s.go
@@ -36,7 +36,6 @@ func (c Cert) String() string {
 // These constants used as Cert parsing a secret received from the API.
 const (
 	APICert                Cert = "api"
-	CalicoCert             Cert = "calico"
 	CalicoEtcdClientCert   Cert = "calico-etcd-client"
 	ClusterOperatorAPICert Cert = "cluster-operator-api"
 	EtcdCert               Cert = "etcd"
@@ -50,7 +49,6 @@ const (
 // AllCerts lists all certificates that can be created by cert-operator.
 var AllCerts = []Cert{
 	APICert,
-	CalicoCert,
 	CalicoEtcdClientCert,
 	ClusterOperatorAPICert,
 	EtcdCert,

--- a/searcher.go
+++ b/searcher.go
@@ -65,7 +65,6 @@ func (s *Searcher) SearchCluster(clusterID string) (Cluster, error) {
 		optional bool
 	}{
 		{TLS: &cluster.APIServer, Cert: APICert},
-		{TLS: &cluster.CalicoClient, Cert: CalicoCert},
 		{TLS: &cluster.CalicoEtcdClient, Cert: CalicoEtcdClientCert, optional: true},
 		{TLS: &cluster.EtcdServer, Cert: EtcdCert},
 		{TLS: &cluster.ServiceAccount, Cert: ServiceAccountCert},


### PR DESCRIPTION
Part of: https://github.com/giantswarm/giantswarm/issues/4173

Naming aligned with Calico CNI script https://github.com/projectcalico/cni-plugin/blob/release-v3.2/k8s-install/scripts/install-cni.sh#L40-L55