### PR TITLE
legacy: Remove calicocert and switch to proper naming

### DIFF
--- a/files.go
+++ b/files.go
@@ -44,22 +44,8 @@ func NewFilesClusterWorker(cluster Cluster) Files {
 
 func newFilesClusterCommon(cluster Cluster) Files {
 	return Files{
-		// Calico client.
-		{
-			AbsolutePath: "/etc/kubernetes/ssl/calico/client-ca.pem",
-			Data:         cluster.CalicoClient.CA,
-		},
-		{
-			AbsolutePath: "/etc/kubernetes/ssl/calico/client-crt.pem",
-			Data:         cluster.CalicoClient.Crt,
-		},
-		{
-			AbsolutePath: "/etc/kubernetes/ssl/calico/client-key.pem",
-			Data:         cluster.CalicoClient.Key,
-		},
-		// Temporary Etcd client keys reusing server keys.
-		// TODO Remove these when operator support for new flannel & calico
-		// specific etcd client keys has been rolled out.
+		// TODO(r7vme): Only used by Calico and should be removed
+		// when Calico will migrate to the ones below.
 		{
 			AbsolutePath: "/etc/kubernetes/ssl/etcd/client-ca.pem",
 			Data:         cluster.EtcdServer.CA,
@@ -74,15 +60,15 @@ func newFilesClusterCommon(cluster Cluster) Files {
 		},
 		// Calico Etcd client.
 		{
-			AbsolutePath: "/etc/kubernetes/ssl/etcd/calico-client-ca.pem",
+			AbsolutePath: "/etc/kubernetes/ssl/calico/etcd-ca",
 			Data:         cluster.CalicoEtcdClient.CA,
 		},
 		{
-			AbsolutePath: "/etc/kubernetes/ssl/etcd/calico-client-crt.pem",
+			AbsolutePath: "/etc/kubernetes/ssl/calico/etcd-cert",
 			Data:         cluster.CalicoEtcdClient.Crt,
 		},
 		{
-			AbsolutePath: "/etc/kubernetes/ssl/etcd/calico-client-key.pem",
+			AbsolutePath: "/etc/kubernetes/ssl/calico/etcd-key",
 			Data:         cluster.CalicoEtcdClient.Key,
 		},
 	}

--- a/files.go
+++ b/files.go
@@ -46,6 +46,7 @@ func newFilesClusterCommon(cluster Cluster) Files {
 	return Files{
 		// TODO(r7vme): Only used by Calico and should be removed
 		// when Calico will migrate to the ones below.
+		// https://github.com/giantswarm/giantswarm/issues/4173
 		{
 			AbsolutePath: "/etc/kubernetes/ssl/etcd/client-ca.pem",
 			Data:         cluster.EtcdServer.CA,

--- a/k8s.go
+++ b/k8s.go
@@ -26,7 +26,6 @@ type Cert string
 // These constants used as Cert parsing a secret received from the API.
 const (
 	APICert                Cert = "api"
-	CalicoCert             Cert = "calico"
 	CalicoEtcdClientCert   Cert = "calico-etcd-client"
 	ClusterOperatorAPICert Cert = "cluster-operator-api"
 	EtcdCert               Cert = "etcd"
@@ -40,7 +39,6 @@ const (
 // AllCerts lists all certificates that can be created by cert-operator.
 var AllCerts = []Cert{
 	APICert,
-	CalicoCert,
 	CalicoEtcdClientCert,
 	ClusterOperatorAPICert,
 	EtcdCert,

--- a/searcher.go
+++ b/searcher.go
@@ -65,7 +65,6 @@ func (s *Searcher) SearchCluster(clusterID string) (Cluster, error) {
 		optional bool
 	}{
 		{TLS: &cluster.APIServer, Cert: APICert},
-		{TLS: &cluster.CalicoClient, Cert: CalicoCert},
 		{TLS: &cluster.CalicoEtcdClient, Cert: CalicoEtcdClientCert, optional: true},
 		{TLS: &cluster.EtcdServer, Cert: EtcdCert},
 		{TLS: &cluster.ServiceAccount, Cert: ServiceAccountCert},


### PR DESCRIPTION
Backport of https://github.com/giantswarm/certs/pull/28 to legace (aws-operator)