### PR TITLE
remove always empty CalicoClient cert leftover

### DIFF
--- a/types.go
+++ b/types.go
@@ -6,7 +6,6 @@ type TLS struct {
 
 type Cluster struct {
 	APIServer        TLS
-	CalicoClient     TLS
 	CalicoEtcdClient TLS
 	EtcdServer       TLS
 	ServiceAccount   TLS


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/4173

Follow up on @r7vme changes.