### PR TITLE
When cert is optional, bail out on error

### DIFF
--- a/searcher.go
+++ b/searcher.go
@@ -124,6 +124,7 @@ func (s *Searcher) SearchCluster(clusterID string) (Cluster, error) {
 			if err != nil {
 				if c.optional {
 					s.logger.Log("level", "warning", "message", err.Error())
+					return nil
 				} else {
 					return microerror.Mask(err)
 				}


### PR DESCRIPTION
When cert searching fails on error but was marked as optional, the function
execution must still end because value of secret is invalid. I hit this issue
on production installation:

```
{"caller":"github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/certs/searcher.go:85","level":"warning","message":"waiting secrets, selector = \"clusterComponent=calico-etcd-client, clusterID=b7sjc\": timeout error","time":"2019-03-21T06:31:30.748002+00:00"}              
panic: runtime error: invalid memory address or nil pointer dereference                                                                      
[signal SIGSEGV: segmentation violation code=0x1 addr=0xb0 pc=0x1132497]                                                                     

goroutine 2807 [running]:
github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/certs.fillTLSFromSecret(0xc000d607c8, 0x0, 0xc000a2c3aa, 0x5, 0x18596ab, 0x12, 0x0, 0x1b724a0)
        /go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/certs/searcher.go:291 +0x37                                  
github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/certs.(*Searcher).SearchCluster.func1(0x0, 0x0)                              
        /go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/certs/searcher.go:93 +0x23a                                  
github.com/giantswarm/kvm-operator/vendor/golang.org/x/sync/errgroup.(*Group).Go.func1(0xc0009516b0, 0xc00015e960)                           
        /go/src/github.com/giantswarm/kvm-operator/vendor/golang.org/x/sync/errgroup/errgroup.go:57 +0x57                                    
created by github.com/giantswarm/kvm-operator/vendor/golang.org/x/sync/errgroup.(*Group).Go                                                  
        /go/src/github.com/giantswarm/kvm-operator/vendor/golang.org/x/sync/errgroup/errgroup.go:54 +0x66 
```

https://gigantic.slack.com/archives/C03CPNRTS/p1553150384130200