### PR TITLE
Drop legacy labels from cert searcher

### DIFF
--- a/k8s.go
+++ b/k8s.go
@@ -12,17 +12,6 @@ const (
 	// containing the certificate.
 	clusterLabel = "giantswarm.io/cluster"
 
-	// legacyCertificateLabel is the label used in the secret to identify a secret
-	// containing the certificate.
-	//
-	// TODO use certificateLabel instead when all cert secrets have it.
-	legacyCertificateLabel = "clusterComponent"
-	// legacyClusterIDLabel is the label used in the secret to identify a secret
-	// containing the certificate.
-	//
-	// TODO use clusterIDLabel instead when all cert secrets have it.
-	legacyClusterIDLabel = "clusterID"
-
 	SecretNamespace = "default"
 )
 
@@ -71,9 +60,7 @@ func K8sName(clusterID string, certificate Cert) string {
 // and the guest cluster ID.
 func K8sLabels(clusterID string, certificate Cert) map[string]string {
 	return map[string]string{
-		certificateLabel:       string(certificate),
-		clusterLabel:           clusterID,
-		legacyCertificateLabel: string(certificate),
-		legacyClusterIDLabel:   clusterID,
+		certificateLabel: string(certificate),
+		clusterLabel:     clusterID,
 	}
 }

--- a/searcher.go
+++ b/searcher.go
@@ -291,7 +291,7 @@ func (s *Searcher) SearchTLS(clusterID string, cert Cert) (TLS, error) {
 func (s *Searcher) search(tls *TLS, clusterID string, cert Cert) (*corev1.Secret, error) {
 	// Select only secrets that match the given certificate and the given
 	// cluster clusterID.
-	selector := fmt.Sprintf("%s=%s, %s=%s", legacyCertificateLabel, cert, legacyClusterIDLabel, clusterID)
+	selector := fmt.Sprintf("%s=%s, %s=%s", certificateLabel, cert, clusterLabel, clusterID)
 
 	watcher, err := s.k8sClient.Core().Secrets(SecretNamespace).Watch(metav1.ListOptions{
 		LabelSelector: selector,
@@ -330,11 +330,11 @@ func (s *Searcher) search(tls *TLS, clusterID string, cert Cert) (*corev1.Secret
 }
 
 func fillTLSFromSecret(tls *TLS, secret *corev1.Secret, clusterID string, cert Cert) error {
-	gotClusterID := secret.Labels[legacyClusterIDLabel]
+	gotClusterID := secret.Labels[clusterLabel]
 	if clusterID != gotClusterID {
 		return microerror.Maskf(invalidSecretError, "expected clusterID = %q, got %q", clusterID, gotClusterID)
 	}
-	gotcert := secret.Labels[legacyCertificateLabel]
+	gotcert := secret.Labels[certificateLabel]
 	if string(cert) != gotcert {
 		return microerror.Maskf(invalidSecretError, "expected certificate = %q, got %q", cert, gotcert)
 	}

--- a/searcher_test.go
+++ b/searcher_test.go
@@ -25,8 +25,8 @@ func Test_fillTLSFromSecret(t *testing.T) {
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"clusterID":        "eggs2",
-						"clusterComponent": "etcd",
+						"giantswarm.io/cluster":     "eggs2",
+						"giantswarm.io/certificate": "etcd",
 					},
 				},
 				Data: map[string][]byte{
@@ -49,8 +49,8 @@ func Test_fillTLSFromSecret(t *testing.T) {
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"clusterID":        "eggs2",
-						"clusterComponent": "etcd",
+						"giantswarm.io/cluster":     "eggs2",
+						"giantswarm.io/certificate": "etcd",
 					},
 				},
 				Data: map[string][]byte{
@@ -69,8 +69,8 @@ func Test_fillTLSFromSecret(t *testing.T) {
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"clusterID":        "eggs2",
-						"clusterComponent": "etcd",
+						"giantswarm.io/cluster":     "eggs2",
+						"giantswarm.io/certificate": "etcd",
 					},
 				},
 				Data: map[string][]byte{
@@ -89,8 +89,8 @@ func Test_fillTLSFromSecret(t *testing.T) {
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"clusterID":        "eggs2",
-						"clusterComponent": "etcd",
+						"giantswarm.io/cluster":     "eggs2",
+						"giantswarm.io/certificate": "etcd",
 					},
 				},
 				Data: map[string][]byte{
@@ -108,8 +108,8 @@ func Test_fillTLSFromSecret(t *testing.T) {
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"clusterID":        "eggs2",
-						"clusterComponent": "etcd",
+						"giantswarm.io/cluster":     "eggs2",
+						"giantswarm.io/certificate": "etcd",
 					},
 				},
 				Data: map[string][]byte{
@@ -127,8 +127,8 @@ func Test_fillTLSFromSecret(t *testing.T) {
 			Secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"clusterID":        "eggs2",
-						"clusterComponent": "etcd",
+						"giantswarm.io/cluster":     "eggs2",
+						"giantswarm.io/certificate": "etcd",
 					},
 				},
 				Data: map[string][]byte{


### PR DESCRIPTION
In Node Pools we don't add legacy labels to objects anymore and hence those
aren't found by cert searcher. Certificate management was recently dropped from
kubernetesd completely (https://github.com/giantswarm/kubernetesd/pull/436) and
cluster-operator has always had both, legacy and current labels so we can be
sure that both labels are found from present clusters. Therefore there
shouldn't be any need for legacy labels any more.