### PR TITLE
Add internal API prefix for alt names

### DIFF
--- a/k8s.go
+++ b/k8s.go
@@ -41,6 +41,7 @@ const (
 	ClusterOperatorAPICert Cert = "cluster-operator-api"
 	EtcdCert               Cert = "etcd"
 	FlanneldEtcdClientCert Cert = "flanneld-etcd-client"
+	InternalAPICert        Cert = "interal-api"
 	NodeOperatorCert       Cert = "node-operator"
 	PrometheusCert         Cert = "prometheus"
 	ServiceAccountCert     Cert = "service-account"
@@ -55,6 +56,7 @@ var AllCerts = []Cert{
 	ClusterOperatorAPICert,
 	EtcdCert,
 	FlanneldEtcdClientCert,
+	InternalAPICert,
 	NodeOperatorCert,
 	PrometheusCert,
 	ServiceAccountCert,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6924
This will be used then in cluster-operator, where `internal-api` will be added into alt-name