### PR TITLE
make TLS response configurable

### DIFF
--- a/pkg/certstest/error.go
+++ b/pkg/certstest/error.go
@@ -1,0 +1,11 @@
+package certstest
+
+import "github.com/giantswarm/microerror"
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/pkg/certstest/searcher.go
+++ b/pkg/certstest/searcher.go
@@ -1,6 +1,8 @@
 package certstest
 
 import (
+	"github.com/giantswarm/microerror"
+
 	"github.com/giantswarm/certs/v2/pkg/certs"
 )
 
@@ -14,7 +16,7 @@ type Config struct {
 	DrainingError        error
 	Monitoring           certs.Monitoring
 	MonitoringError      error
-	TLS                  certs.TLS
+	TLS                  map[string]map[string]certs.TLS
 	TLSError             error
 }
 
@@ -27,7 +29,7 @@ type Searcher struct {
 	drainingError        error
 	monitoring           certs.Monitoring
 	monitoringError      error
-	tls                  certs.TLS
+	tls                  map[string]map[string]certs.TLS
 	tlsError             error
 }
 
@@ -83,5 +85,15 @@ func (s *Searcher) SearchTLS(clusterID string, cert certs.Cert) (certs.TLS, erro
 		return certs.TLS{}, s.tlsError
 	}
 
-	return s.tls, nil
+	cm, ok := s.tls[clusterID]
+	if !ok {
+		return certs.TLS{}, microerror.Mask(notFoundError)
+	}
+
+	tls, ok := cm[cert.String()]
+	if !ok {
+		return certs.TLS{}, microerror.Mask(notFoundError)
+	}
+
+	return tls, nil
 }

--- a/pkg/certstest/searcher.go
+++ b/pkg/certstest/searcher.go
@@ -16,7 +16,7 @@ type Config struct {
 	DrainingError        error
 	Monitoring           certs.Monitoring
 	MonitoringError      error
-	TLS                  map[string]map[string]certs.TLS
+	TLS                  map[string]map[certs.Cert]certs.TLS
 	TLSError             error
 }
 
@@ -29,7 +29,7 @@ type Searcher struct {
 	drainingError        error
 	monitoring           certs.Monitoring
 	monitoringError      error
-	tls                  map[string]map[string]certs.TLS
+	tls                  map[string]map[certs.Cert]certs.TLS
 	tlsError             error
 }
 
@@ -90,7 +90,7 @@ func (s *Searcher) SearchTLS(clusterID string, cert certs.Cert) (certs.TLS, erro
 		return certs.TLS{}, microerror.Mask(notFoundError)
 	}
 
-	tls, ok := cm[cert.String()]
+	tls, ok := cm[cert]
 	if !ok {
 		return certs.TLS{}, microerror.Mask(notFoundError)
 	}


### PR DESCRIPTION
## Checklist

- [ ] Update changelog in CHANGELOG.md.



## Context

I want to figure out a way to make k8scc testing a thing in the `aws-operator`. I tried to use the stubbing of the fake k8s client but this does not seem to work with watches which we do in the certs searcher and random key searcher. So I thought we just mock the whole thing and here we go. Still PoCing. 