### PR TITLE
watch secrets across all namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for secrets in other namespaces than `default`.
+
 ## [3.0.0] - 2020-08-10
 
 ### Changed

--- a/pkg/certs/k8s.go
+++ b/pkg/certs/k8s.go
@@ -1,9 +1,14 @@
 package certs
 
-import "fmt"
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 const (
-	SecretNamespace = "default"
+	// SecretNamespace is the namespace in which secrets are watched.
+	SecretNamespace = metav1.NamespaceAll
 )
 
 // These constants are used when filtering the secrets, to only retrieve the


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/12647

We want to be able to watch secrets across all namespaces other than the `default` namespace.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
