### PR TITLE
Restore AllCerts list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Restore `AllCerts` list of `cert-operator`-managed certificates.
+
 ## [3.1.0] - 2020-09-28
 
 ### Added

--- a/pkg/certs/certs.go
+++ b/pkg/certs/certs.go
@@ -27,3 +27,23 @@ const (
 	ServiceAccountCert       Cert = "service-account"
 	WorkerCert               Cert = "worker"
 )
+
+// AllCerts lists all certificates that can be created by cert-operator.
+var AllCerts = []Cert{
+	APICert,
+	AppOperatorAPICert,
+	AWSOperatorAPICert,
+	CalicoEtcdClientCert,
+	ClusterOperatorAPICert,
+	EtcdCert,
+	Etcd1Cert,
+	Etcd2Cert,
+	Etcd3Cert,
+	FlanneldEtcdClientCert,
+	InternalAPICert,
+	NodeOperatorCert,
+	PrometheusCert,
+	PrometheusEtcdClientCert,
+	ServiceAccountCert,
+	WorkerCert,
+}


### PR DESCRIPTION
[A previous refactor](https://github.com/giantswarm/certs/pull/68/files#diff-6d02a59a8c7a7cf239da86a38a3e0cb1d83f4a6ac45dd274b59a1e22f73bdbc8L53-L66) accidentally dropped this list, but it is still needed by `cert-operator`.

Towards https://github.com/giantswarm/giantswarm/issues/14205 and https://github.com/giantswarm/cert-operator/pull/364 

## Checklist

- [x] Update changelog in CHANGELOG.md.
